### PR TITLE
vim_addon_nix#CheckSyntax: skip unreadable files

### DIFF
--- a/autoload/vim_addon_nix.vim
+++ b/autoload/vim_addon_nix.vim
@@ -7,6 +7,9 @@ if !exists('g:nix_syntax_check_error_list')
 endif
 
 fun! vim_addon_nix#CheckSyntax()
+  if !filereadable(expand('%'))
+    return
+  endif
   let p = g:nix_syntax_check_error_list
   if !exists('s:tmpfile')
     let s:tmpfile = tempname()


### PR DESCRIPTION
This fixes errors when using fugitive for example.
